### PR TITLE
Remove frequency preference, default to daily sessions

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-ce4f0d5f'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.arse48450r8"
+    "revision": "0.58157lptn88"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-ce4f0d5f'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.58157lptn88"
+    "revision": "0.kf4j9fii6v8"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/components/TaskInput.tsx
+++ b/src/components/TaskInput.tsx
@@ -928,36 +928,73 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
               </div>
 
               {/* Auto-calculated preview */}
-              {formData.startDate && formData.deadline && (
-                <div className="p-3 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600">
-                  <div className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">Automatic Calculation:</div>
-                  <div className="grid grid-cols-2 gap-4 text-sm">
-                    <div>
-                      <div className="text-gray-500 dark:text-gray-400">Session Duration:</div>
-                      <div className="font-medium text-gray-800 dark:text-white">
-                        {sessionData.sessionHours}h {sessionData.sessionMinutes}m
+              {formData.startDate && formData.deadline && (() => {
+                const calculation = calculateSessionBasedTime();
+                return (
+                  <div className={`p-3 rounded-lg border ${
+                    calculation.feasible
+                      ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600'
+                      : 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-700'
+                  }`}>
+                    <div className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">Automatic Calculation:</div>
+                    <div className="grid grid-cols-3 gap-3 text-sm">
+                      <div>
+                        <div className="text-gray-500 dark:text-gray-400">Session Duration:</div>
+                        <div className="font-medium text-gray-800 dark:text-white">
+                          {sessionData.sessionHours}h {sessionData.sessionMinutes}m
+                        </div>
+                      </div>
+                      <div>
+                        <div className="text-gray-500 dark:text-gray-400">Planned Sessions:</div>
+                        <div className="font-medium text-gray-800 dark:text-white">
+                          {calculation.sessions} sessions
+                        </div>
+                      </div>
+                      <div>
+                        <div className="text-gray-500 dark:text-gray-400">Total Time:</div>
+                        <div className={`font-medium ${
+                          calculation.feasible
+                            ? 'text-blue-600 dark:text-blue-400'
+                            : 'text-red-600 dark:text-red-400'
+                        }`}>
+                          {calculation.totalTime > 0 ? `${calculation.totalTime.toFixed(1)}h` : 'Set session duration'}
+                        </div>
                       </div>
                     </div>
-                    <div>
-                      <div className="text-gray-500 dark:text-gray-400">Total Time:</div>
-                      <div className="font-medium text-blue-600 dark:text-blue-400">
-                        {calculateSessionBasedTime() > 0 ? `${calculateSessionBasedTime().toFixed(1)}h` : 'Set dates first'}
+
+                    {calculation.frequency && (
+                      <div className="mt-2 flex items-center space-x-1">
+                        <span className="text-xs text-gray-500 dark:text-gray-400">Frequency:</span>
+                        <span className="text-xs font-medium text-gray-700 dark:text-gray-300">{calculation.frequency}</span>
                       </div>
-                    </div>
+                    )}
+
+                    {calculation.warning && (
+                      <div className="mt-2 flex items-start space-x-2 text-xs text-red-600 dark:text-red-400">
+                        <svg className="w-4 h-4 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        <span>{calculation.warning}</span>
+                      </div>
+                    )}
+
+                    {calculation.feasible && calculation.totalTime > 0 && (
+                      <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                        The app will automatically schedule {calculation.sessions} sessions based on your availability.
+                      </div>
+                    )}
                   </div>
-                  {calculateSessionBasedTime() > 0 && (
-                    <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-                      Based on your start date and deadline, the app will schedule sessions as needed.
-                    </div>
-                  )}
+                );
+              })()}
+
+              {(!formData.startDate || !formData.deadline) && (
+                <div className="text-sm text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 p-3 rounded-lg flex items-center space-x-2">
+                  <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  <span>Please set both start date and deadline to see the automatic calculation.</span>
                 </div>
               )}
-
-              {!formData.startDate || !formData.deadline ? (
-                <div className="text-sm text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 p-3 rounded-lg">
-                  Please set both start date and deadline to see the automatic calculation.
-                </div>
-              ) : null}
             </div>
           )}
         </div>
@@ -1102,7 +1139,7 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
         {(!isFormValid || isFormInvalid) && (
           <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 rounded-lg mt-4">
             <div className="flex items-start gap-2">
-              <span className="text-red-500 text-lg">��️</span>
+              <span className="text-red-500 text-lg">⚠️</span>
               <div className="text-sm text-red-700 dark:text-red-200">
                 <div className="font-semibold mb-2">Cannot Add Task - Please Fix These Issues:</div>
                 <ul className="space-y-1 text-xs">

--- a/src/components/TaskInput.tsx
+++ b/src/components/TaskInput.tsx
@@ -704,97 +704,216 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
             placeholder="Describe the task..."
               />
             </div>
-        {/* Estimated Time - New Dual Input System */}
-        <div className="flex flex-col md:flex-row md:items-center gap-2">
-          <div className="flex-1">
-            <label className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-1">Estimated Time <span className="text-red-500">*</span></label>
-            <div className="flex gap-2 items-center">
-              <div className="flex-1">
-                <input
-                  type="number"
-                  min="0"
-                  value={formData.estimatedHours}
-                  onChange={e => {
-                    const value = e.target.value;
-                    if (value === '' || (/^\d*$/.test(value) && parseInt(value) >= 0)) {
-                      setFormData(f => ({ ...f, estimatedHours: value }));
-                    }
-                  }}
-                  className="w-full border rounded-lg px-3 py-2 text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent border-gray-300 bg-white dark:bg-gray-800 dark:text-white"
-                  placeholder="0"
-                />
-                <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">Hours</div>
-              </div>
-              <div className="text-gray-500 dark:text-gray-400 text-lg font-bold">:</div>
-              <div className="flex-1">
-                <input
-                  type="number"
-                  min="0"
-                  max="59"
-                  value={formData.estimatedMinutes}
-                  onChange={e => {
-                    const value = e.target.value;
-                    if (value === '' || /^\d*$/.test(value)) {
-                      const numValue = parseInt(value) || 0;
-                      if (numValue >= 0 && numValue <= 59) {
-                        setFormData(f => ({ ...f, estimatedMinutes: value }));
-                      }
-                    }
-                  }}
-                  className="w-full border rounded-lg px-3 py-2 text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent border-gray-300 bg-white dark:bg-gray-800 dark:text-white"
-                  placeholder="0"
-                />
-                <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">Minutes</div>
-              </div>
-            </div>
-            <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              {totalTime > 0 && (
-                <span className="text-blue-600 dark:text-blue-400 font-medium">
-                  {formatTimeDisplay(formData.estimatedHours, formData.estimatedMinutes)} 
-                  {totalTime !== Math.round(totalTime) && ` (${totalTime.toFixed(1)} hours)`}
-                </span>
-              )}
-            </div>
-            
-            {/* Time Presets - Hidden by default */}
-            <div className="mt-2">
+        {/* Estimated Time - Mode Toggle and Input System */}
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <label className="block text-sm font-semibold text-gray-700 dark:text-gray-200">Estimated Time <span className="text-red-500">*</span></label>
+            <div className="flex bg-gray-100 dark:bg-gray-700 rounded-lg p-1">
               <button
                 type="button"
-                onClick={() => setShowTimePresets(!showTimePresets)}
-                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                onClick={() => setEstimationMode('total')}
+                className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                  estimationMode === 'total'
+                    ? 'bg-white dark:bg-gray-600 text-blue-600 dark:text-blue-400 shadow-sm'
+                    : 'text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200'
+                }`}
               >
-                {showTimePresets ? 'Hide quick presets' : 'Show quick presets'}
+                Total Time
               </button>
-              {showTimePresets && (
-                <div className="mt-1">
-                  <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Quick presets:</div>
-                  <div className="flex flex-wrap gap-1">
-                    {timePresets.map((preset, index) => (
-                      <button
-                        key={index}
-                        type="button"
-                        onClick={() => setFormData(f => ({ 
-                          ...f, 
-                          estimatedHours: preset.hours, 
-                          estimatedMinutes: preset.minutes 
-                        }))}
-                        className="px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white rounded border transition-colors"
-                      >
-                        {preset.label}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
+              <button
+                type="button"
+                onClick={() => setEstimationMode('session')}
+                className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                  estimationMode === 'session'
+                    ? 'bg-white dark:bg-gray-600 text-blue-600 dark:text-blue-400 shadow-sm'
+                    : 'text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200'
+                }`}
+              >
+                Session Planning
+              </button>
             </div>
           </div>
-          <button
-            type="button"
-            className="text-blue-600 underline text-sm mt-2 md:mt-6 md:ml-4 whitespace-nowrap"
-            onClick={handleShowEstimationHelper}
-          >
-            Need help estimating?
-          </button>
+
+          {estimationMode === 'total' ? (
+            <div className="flex flex-col md:flex-row md:items-center gap-2">
+              <div className="flex-1">
+                <div className="flex gap-2 items-center">
+                  <div className="flex-1">
+                    <input
+                      type="number"
+                      min="0"
+                      value={formData.estimatedHours}
+                      onChange={e => {
+                        const value = e.target.value;
+                        if (value === '' || (/^\d*$/.test(value) && parseInt(value) >= 0)) {
+                          setFormData(f => ({ ...f, estimatedHours: value }));
+                        }
+                      }}
+                      className="w-full border rounded-lg px-3 py-2 text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent border-gray-300 bg-white dark:bg-gray-800 dark:text-white"
+                      placeholder="0"
+                    />
+                    <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">Hours</div>
+                  </div>
+                  <div className="text-gray-500 dark:text-gray-400 text-lg font-bold">:</div>
+                  <div className="flex-1">
+                    <input
+                      type="number"
+                      min="0"
+                      max="59"
+                      value={formData.estimatedMinutes}
+                      onChange={e => {
+                        const value = e.target.value;
+                        if (value === '' || /^\d*$/.test(value)) {
+                          const numValue = parseInt(value) || 0;
+                          if (numValue >= 0 && numValue <= 59) {
+                            setFormData(f => ({ ...f, estimatedMinutes: value }));
+                          }
+                        }
+                      }}
+                      className="w-full border rounded-lg px-3 py-2 text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent border-gray-300 bg-white dark:bg-gray-800 dark:text-white"
+                      placeholder="0"
+                    />
+                    <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">Minutes</div>
+                  </div>
+                </div>
+                <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  {totalTime > 0 && (
+                    <span className="text-blue-600 dark:text-blue-400 font-medium">
+                      {formatTimeDisplay(formData.estimatedHours, formData.estimatedMinutes)}
+                      {totalTime !== Math.round(totalTime) && ` (${totalTime.toFixed(1)} hours)`}
+                    </span>
+                  )}
+                </div>
+
+                {/* Time Presets - Hidden by default */}
+                <div className="mt-2">
+                  <button
+                    type="button"
+                    onClick={() => setShowTimePresets(!showTimePresets)}
+                    className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                  >
+                    {showTimePresets ? 'Hide quick presets' : 'Show quick presets'}
+                  </button>
+                  {showTimePresets && (
+                    <div className="mt-1">
+                      <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Quick presets:</div>
+                      <div className="flex flex-wrap gap-1">
+                        {timePresets.map((preset, index) => (
+                          <button
+                            key={index}
+                            type="button"
+                            onClick={() => setFormData(f => ({
+                              ...f,
+                              estimatedHours: preset.hours,
+                              estimatedMinutes: preset.minutes
+                            }))}
+                            className="px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white rounded border transition-colors"
+                          >
+                            {preset.label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <button
+                type="button"
+                className="text-blue-600 underline text-sm mt-2 md:mt-6 md:ml-4 whitespace-nowrap"
+                onClick={handleShowEstimationHelper}
+              >
+                Need help estimating?
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-4 p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-700">
+              <div className="flex items-center space-x-2 text-blue-700 dark:text-blue-300">
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <span className="font-medium text-sm">Session-Based Planning</span>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
+                  How long will each work session be?
+                </label>
+                <div className="flex gap-2 items-center">
+                  <div className="flex-1">
+                    <input
+                      type="number"
+                      min="0"
+                      max="8"
+                      value={sessionData.sessionHours}
+                      onChange={e => {
+                        const value = e.target.value;
+                        if (value === '' || (/^\d*$/.test(value) && parseInt(value) >= 0 && parseInt(value) <= 8)) {
+                          setSessionData(prev => ({ ...prev, sessionHours: value }));
+                        }
+                      }}
+                      className="w-full border rounded-lg px-3 py-2 text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent border-gray-300 bg-white dark:bg-gray-800 dark:text-white"
+                      placeholder="2"
+                    />
+                    <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">Hours</div>
+                  </div>
+                  <div className="text-gray-500 dark:text-gray-400 text-lg font-bold">:</div>
+                  <div className="flex-1">
+                    <input
+                      type="number"
+                      min="0"
+                      max="59"
+                      step="15"
+                      value={sessionData.sessionMinutes}
+                      onChange={e => {
+                        const value = e.target.value;
+                        if (value === '' || /^\d*$/.test(value)) {
+                          const numValue = parseInt(value) || 0;
+                          if (numValue >= 0 && numValue <= 59) {
+                            setSessionData(prev => ({ ...prev, sessionMinutes: value }));
+                          }
+                        }
+                      }}
+                      className="w-full border rounded-lg px-3 py-2 text-base focus:ring-2 focus:ring-blue-500 focus:border-transparent border-gray-300 bg-white dark:bg-gray-800 dark:text-white"
+                      placeholder="0"
+                    />
+                    <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">Minutes</div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Auto-calculated preview */}
+              {formData.startDate && formData.deadline && (
+                <div className="p-3 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-600">
+                  <div className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">Automatic Calculation:</div>
+                  <div className="grid grid-cols-2 gap-4 text-sm">
+                    <div>
+                      <div className="text-gray-500 dark:text-gray-400">Session Duration:</div>
+                      <div className="font-medium text-gray-800 dark:text-white">
+                        {sessionData.sessionHours}h {sessionData.sessionMinutes}m
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-gray-500 dark:text-gray-400">Total Time:</div>
+                      <div className="font-medium text-blue-600 dark:text-blue-400">
+                        {calculateSessionBasedTime() > 0 ? `${calculateSessionBasedTime().toFixed(1)}h` : 'Set dates first'}
+                      </div>
+                    </div>
+                  </div>
+                  {calculateSessionBasedTime() > 0 && (
+                    <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                      Based on your start date and deadline, the app will schedule sessions as needed.
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {!formData.startDate || !formData.deadline ? (
+                <div className="text-sm text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 p-3 rounded-lg">
+                  Please set both start date and deadline to see the automatic calculation.
+                </div>
+              ) : null}
+            </div>
+          )}
         </div>
         {/* Impact */}
         <div>

--- a/src/components/TaskInput.tsx
+++ b/src/components/TaskInput.tsx
@@ -118,6 +118,14 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
     isOneTimeTask: false, // New field for one-time tasks
     startDate: new Date().toISOString().split('T')[0], // New: start date defaults to today
   });
+
+  // Session-based estimation state
+  const [estimationMode, setEstimationMode] = useState<'total' | 'session'>('total');
+  const [sessionData, setSessionData] = useState({
+    sessionDuration: '2.0', // Default 2 hours per session
+    sessionHours: '2',
+    sessionMinutes: '0'
+  });
   const [showMoreOptions, setShowMoreOptions] = useState(false);
   const [showTimePresets, setShowTimePresets] = useState(false);
   const [showTaskTimeline, setShowTaskTimeline] = useState(false);
@@ -146,6 +154,52 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
   }, [formData.deadline]);
 
 
+
+  // Calculate session-based total time
+  const calculateSessionBasedTime = () => {
+    if (!formData.startDate || !formData.deadline || estimationMode !== 'session') {
+      return 0;
+    }
+
+    const startDate = new Date(formData.startDate);
+    const endDate = new Date(formData.deadline);
+    const timeDiff = endDate.getTime() - startDate.getTime();
+    const daysDiff = Math.ceil(timeDiff / (1000 * 3600 * 24));
+
+    if (daysDiff <= 0) return 0;
+
+    // Calculate sessions based on work days (exclude weekends if not in workDays)
+    const workDaysInRange = Math.ceil(daysDiff * (userSettings.workDays.length / 7));
+
+    // Conservative approach: assume we can do 1 session every 2-3 work days
+    const sessionFrequency = Math.max(1, Math.floor(workDaysInRange / 3));
+    const numberOfSessions = Math.max(1, sessionFrequency);
+
+    const sessionDuration = parseFloat(sessionData.sessionDuration) || 0;
+    return sessionDuration * numberOfSessions;
+  };
+
+  // Update total time when session data changes
+  useEffect(() => {
+    if (estimationMode === 'session') {
+      const sessionHours = parseInt(sessionData.sessionHours) || 0;
+      const sessionMinutes = parseInt(sessionData.sessionMinutes) || 0;
+      const sessionDuration = sessionHours + sessionMinutes / 60;
+
+      setSessionData(prev => ({ ...prev, sessionDuration: sessionDuration.toString() }));
+
+      const totalTime = calculateSessionBasedTime();
+      if (totalTime > 0) {
+        const hours = Math.floor(totalTime);
+        const minutes = Math.round((totalTime - hours) * 60);
+        setFormData(prev => ({
+          ...prev,
+          estimatedHours: hours.toString(),
+          estimatedMinutes: minutes.toString()
+        }));
+      }
+    }
+  }, [sessionData.sessionHours, sessionData.sessionMinutes, formData.startDate, formData.deadline, estimationMode, userSettings.workDays]);
 
   // Check if form is valid for submission
   const isFormInvalid = useMemo(() => {

--- a/src/components/TaskInput.tsx
+++ b/src/components/TaskInput.tsx
@@ -155,10 +155,10 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
 
 
 
-  // Calculate session-based total time
+  // Calculate session-based total time and metadata
   const calculateSessionBasedTime = () => {
     if (!formData.startDate || !formData.deadline || estimationMode !== 'session') {
-      return 0;
+      return { totalTime: 0, sessions: 0, frequency: '', feasible: true, warning: '' };
     }
 
     const startDate = new Date(formData.startDate);
@@ -166,32 +166,78 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
     const timeDiff = endDate.getTime() - startDate.getTime();
     const daysDiff = Math.ceil(timeDiff / (1000 * 3600 * 24));
 
-    if (daysDiff <= 0) return 0;
+    if (daysDiff <= 0) {
+      return { totalTime: 0, sessions: 0, frequency: 'Invalid date range', feasible: false, warning: 'Deadline must be after start date' };
+    }
 
-    // Calculate sessions based on work days (exclude weekends if not in workDays)
-    const workDaysInRange = Math.ceil(daysDiff * (userSettings.workDays.length / 7));
+    const sessionDuration = (parseInt(sessionData.sessionHours) || 0) + (parseInt(sessionData.sessionMinutes) || 0) / 60;
+    if (sessionDuration <= 0) {
+      return { totalTime: 0, sessions: 0, frequency: '', feasible: true, warning: '' };
+    }
 
-    // Conservative approach: assume we can do 1 session every 2-3 work days
-    const sessionFrequency = Math.max(1, Math.floor(workDaysInRange / 3));
-    const numberOfSessions = Math.max(1, sessionFrequency);
+    // Calculate work days in the range
+    let workDaysInRange = 0;
+    const currentDate = new Date(startDate);
 
-    const sessionDuration = parseFloat(sessionData.sessionDuration) || 0;
-    return sessionDuration * numberOfSessions;
+    while (currentDate <= endDate) {
+      const dayOfWeek = currentDate.getDay();
+      if (userSettings.workDays.includes(dayOfWeek)) {
+        workDaysInRange++;
+      }
+      currentDate.setDate(currentDate.getDate() + 1);
+    }
+
+    if (workDaysInRange === 0) {
+      return { totalTime: 0, sessions: 0, frequency: 'No work days', feasible: false, warning: 'No work days in the selected range' };
+    }
+
+    // Calculate optimal session distribution
+    let numberOfSessions;
+    let frequency;
+
+    if (workDaysInRange <= 5) {
+      // Short timeline: 1 session every other work day
+      numberOfSessions = Math.max(1, Math.ceil(workDaysInRange / 2));
+      frequency = 'Every 2-3 days';
+    } else if (workDaysInRange <= 14) {
+      // Medium timeline: 2-3 sessions per week
+      numberOfSessions = Math.max(2, Math.ceil(workDaysInRange * 0.4));
+      frequency = '2-3 times per week';
+    } else {
+      // Long timeline: 2-3 sessions per week
+      numberOfSessions = Math.max(3, Math.ceil(workDaysInRange * 0.3));
+      frequency = '2-3 times per week';
+    }
+
+    const totalTime = sessionDuration * numberOfSessions;
+
+    // Check feasibility
+    const dailyCapacity = userSettings.dailyAvailableHours;
+    const totalCapacity = workDaysInRange * dailyCapacity;
+    let feasible = true;
+    let warning = '';
+
+    if (sessionDuration > dailyCapacity) {
+      feasible = false;
+      warning = `Session duration (${sessionDuration.toFixed(1)}h) exceeds daily capacity (${dailyCapacity}h)`;
+    } else if (totalTime > totalCapacity * 0.8) {
+      feasible = false;
+      warning = `Total time (${totalTime.toFixed(1)}h) may exceed available capacity`;
+    } else if (numberOfSessions > workDaysInRange) {
+      feasible = false;
+      warning = 'Not enough work days for planned sessions';
+    }
+
+    return { totalTime, sessions: numberOfSessions, frequency, feasible, warning };
   };
 
   // Update total time when session data changes
   useEffect(() => {
     if (estimationMode === 'session') {
-      const sessionHours = parseInt(sessionData.sessionHours) || 0;
-      const sessionMinutes = parseInt(sessionData.sessionMinutes) || 0;
-      const sessionDuration = sessionHours + sessionMinutes / 60;
-
-      setSessionData(prev => ({ ...prev, sessionDuration: sessionDuration.toString() }));
-
-      const totalTime = calculateSessionBasedTime();
-      if (totalTime > 0) {
-        const hours = Math.floor(totalTime);
-        const minutes = Math.round((totalTime - hours) * 60);
+      const calculation = calculateSessionBasedTime();
+      if (calculation.totalTime > 0) {
+        const hours = Math.floor(calculation.totalTime);
+        const minutes = Math.round((calculation.totalTime - hours) * 60);
         setFormData(prev => ({
           ...prev,
           estimatedHours: hours.toString(),
@@ -1056,7 +1102,7 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
         {(!isFormValid || isFormInvalid) && (
           <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 rounded-lg mt-4">
             <div className="flex items-start gap-2">
-              <span className="text-red-500 text-lg">⚠️</span>
+              <span className="text-red-500 text-lg">��️</span>
               <div className="text-sm text-red-700 dark:text-red-200">
                 <div className="font-semibold mb-2">Cannot Add Task - Please Fix These Issues:</div>
                 <ul className="space-y-1 text-xs">

--- a/src/components/TaskInput.tsx
+++ b/src/components/TaskInput.tsx
@@ -191,23 +191,9 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
       return { totalTime: 0, sessions: 0, frequency: 'No work days', feasible: false, warning: 'No work days in the selected range' };
     }
 
-    // Calculate optimal session distribution
-    let numberOfSessions;
-    let frequency;
-
-    if (workDaysInRange <= 5) {
-      // Short timeline: 1 session every other work day
-      numberOfSessions = Math.max(1, Math.ceil(workDaysInRange / 2));
-      frequency = 'Every 2-3 days';
-    } else if (workDaysInRange <= 14) {
-      // Medium timeline: 2-3 sessions per week
-      numberOfSessions = Math.max(2, Math.ceil(workDaysInRange * 0.4));
-      frequency = '2-3 times per week';
-    } else {
-      // Long timeline: 2-3 sessions per week
-      numberOfSessions = Math.max(3, Math.ceil(workDaysInRange * 0.3));
-      frequency = '2-3 times per week';
-    }
+    // Calculate sessions - default to daily
+    const numberOfSessions = workDaysInRange;
+    const frequency = 'Daily';
 
     const totalTime = sessionDuration * numberOfSessions;
 
@@ -223,9 +209,6 @@ const TaskInput: React.FC<TaskInputProps> = ({ onAddTask, onCancel, userSettings
     } else if (totalTime > totalCapacity * 0.8) {
       feasible = false;
       warning = `Total time (${totalTime.toFixed(1)}h) may exceed available capacity`;
-    } else if (numberOfSessions > workDaysInRange) {
-      feasible = false;
-      warning = 'Not enough work days for planned sessions';
     }
 
     return { totalTime, sessions: numberOfSessions, frequency, feasible, warning };

--- a/src/components/TaskInputSimplified.tsx
+++ b/src/components/TaskInputSimplified.tsx
@@ -105,20 +105,9 @@ const TaskInputSimplified: React.FC<TaskInputProps> = ({ onAddTask, onCancel, us
       return { totalTime: 0, sessions: 0, frequency: 'No work days', feasible: false, warning: 'No work days in the selected range' };
     }
 
-    // Calculate optimal session distribution
-    let numberOfSessions;
-    let frequency;
-
-    if (workDaysInRange <= 5) {
-      numberOfSessions = Math.max(1, Math.ceil(workDaysInRange / 2));
-      frequency = 'Every 2-3 days';
-    } else if (workDaysInRange <= 14) {
-      numberOfSessions = Math.max(2, Math.ceil(workDaysInRange * 0.4));
-      frequency = '2-3 times per week';
-    } else {
-      numberOfSessions = Math.max(3, Math.ceil(workDaysInRange * 0.3));
-      frequency = '2-3 times per week';
-    }
+    // Calculate sessions - default to daily
+    const numberOfSessions = workDaysInRange;
+    const frequency = 'Daily';
 
     const totalTime = sessionDuration * numberOfSessions;
 
@@ -134,9 +123,6 @@ const TaskInputSimplified: React.FC<TaskInputProps> = ({ onAddTask, onCancel, us
     } else if (totalTime > totalCapacity * 0.8) {
       feasible = false;
       warning = `Total time (${totalTime.toFixed(1)}h) may exceed available capacity`;
-    } else if (numberOfSessions > workDaysInRange) {
-      feasible = false;
-      warning = 'Not enough work days for planned sessions';
     }
 
     return { totalTime, sessions: numberOfSessions, frequency, feasible, warning };

--- a/src/components/TaskInputSimplified.tsx
+++ b/src/components/TaskInputSimplified.tsx
@@ -619,98 +619,249 @@ const TaskInputSimplified: React.FC<TaskInputProps> = ({ onAddTask, onCancel, us
 
 
           {/* 7. Time Estimation */}
-          <div>
-            <div className="flex items-center justify-between mb-2">
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
               <label className="block text-sm font-semibold text-gray-700 dark:text-gray-200">
                 Time Estimation <span className="text-red-500">*</span>
               </label>
+              <div className="flex bg-gray-100 dark:bg-gray-700 rounded-lg p-1">
+                <button
+                  type="button"
+                  onClick={() => setEstimationMode('total')}
+                  className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                    estimationMode === 'total'
+                      ? 'bg-white dark:bg-gray-600 text-violet-600 dark:text-violet-400 shadow-sm'
+                      : 'text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200'
+                  }`}
+                >
+                  Total Time
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setEstimationMode('session')}
+                  className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                    estimationMode === 'session'
+                      ? 'bg-white dark:bg-gray-600 text-violet-600 dark:text-violet-400 shadow-sm'
+                      : 'text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200'
+                  }`}
+                >
+                  Session Planning
+                </button>
+              </div>
             </div>
 
-            <div className="space-y-2">
-              <div className="flex items-center space-x-3">
-                <div className="flex-1 p-3 border border-white/30 dark:border-white/20 rounded-xl bg-white/70 dark:bg-black/20">
-                  <div className="flex items-center justify-between">
-                    <div className="text-lg font-medium text-gray-800 dark:text-white">
-                      {totalTime > 0 ? formatTimeDisplay(formData.estimatedHours, formData.estimatedMinutes) : 'Not set'}
+            {estimationMode === 'total' ? (
+              <div className="space-y-2">
+                <div className="flex items-center space-x-3">
+                  <div className="flex-1 p-3 border border-white/30 dark:border-white/20 rounded-xl bg-white/70 dark:bg-black/20">
+                    <div className="flex items-center justify-between">
+                      <div className="text-lg font-medium text-gray-800 dark:text-white">
+                        {totalTime > 0 ? formatTimeDisplay(formData.estimatedHours, formData.estimatedMinutes) : 'Not set'}
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {formData.estimatedHours && (
+                          <button
+                            type="button"
+                            aria-label="Clear hours"
+                            title="Clear hours"
+                            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                            onClick={() => setFormData(f => ({ ...f, estimatedHours: '' }))}
+                          >
+                            <X size={16} />
+                          </button>
+                        )}
+                        {(formData.estimatedMinutes && formData.estimatedMinutes !== '0') && (
+                          <button
+                            type="button"
+                            aria-label="Clear minutes"
+                            title="Clear minutes"
+                            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                            onClick={() => setFormData(f => ({ ...f, estimatedMinutes: '0' }))}
+                          >
+                            <X size={16} />
+                          </button>
+                        )}
+                      </div>
                     </div>
-                    <div className="flex items-center gap-2">
-                      {formData.estimatedHours && (
+                    {formData.taskType && (
+                      <div className="text-sm text-gray-600 dark:text-gray-400">
+                        Task type: {formData.taskType}
+                      </div>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setShowTimeEstimationModal(true)}
+                    className="flex items-center space-x-2 px-4 py-3 bg-violet-600 hover:bg-violet-700 text-white rounded-xl transition-colors"
+                  >
+                    <Clock size={18} />
+                    <span>Estimate</span>
+                  </button>
+                </div>
+                <div className="flex items-center gap-4 text-xs">
+                  <button
+                    type="button"
+                    onClick={() => setShowTimeEstimationModal(true)}
+                    className="text-violet-600 dark:text-violet-400 hover:underline"
+                  >
+                    Need help estimating?
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setShowTimePresets(!showTimePresets)}
+                    className="text-violet-600 dark:text-violet-400 hover:underline"
+                  >
+                    {showTimePresets ? 'Hide quick presets' : 'Show quick presets'}
+                  </button>
+                </div>
+                {showTimePresets && (
+                  <div className="mt-1">
+                    <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Quick presets:</div>
+                    <div className="flex flex-wrap gap-1">
+                      {timePresets.map((preset, index) => (
                         <button
+                          key={index}
                           type="button"
-                          aria-label="Clear hours"
-                          title="Clear hours"
-                          className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
-                          onClick={() => setFormData(f => ({ ...f, estimatedHours: '' }))}
+                          onClick={() => setFormData(f => ({
+                            ...f,
+                            estimatedHours: preset.hours,
+                            estimatedMinutes: preset.minutes,
+                          }))}
+                          className="px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white rounded border transition-colors"
                         >
-                          <X size={16} />
+                          {preset.label}
                         </button>
-                      )}
-                      {(formData.estimatedMinutes && formData.estimatedMinutes !== '0') && (
-                        <button
-                          type="button"
-                          aria-label="Clear minutes"
-                          title="Clear minutes"
-                          className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
-                          onClick={() => setFormData(f => ({ ...f, estimatedMinutes: '0' }))}
-                        >
-                          <X size={16} />
-                        </button>
-                      )}
+                      ))}
                     </div>
                   </div>
-                  {formData.taskType && (
-                    <div className="text-sm text-gray-600 dark:text-gray-400">
-                      Task type: {formData.taskType}
-                    </div>
-                  )}
+                )}
+              </div>
+            ) : (
+              <div className="space-y-4 p-4 bg-violet-50 dark:bg-violet-900/20 rounded-xl border border-violet-200 dark:border-violet-700">
+                <div className="flex items-center space-x-2 text-violet-700 dark:text-violet-300">
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  <span className="font-medium text-sm">Session-Based Planning</span>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => setShowTimeEstimationModal(true)}
-                  className="flex items-center space-x-2 px-4 py-3 bg-violet-600 hover:bg-violet-700 text-white rounded-xl transition-colors"
-                >
-                  <Clock size={18} />
-                  <span>Estimate</span>
-                </button>
-              </div>
-              <div className="flex items-center gap-4 text-xs">
-                <button
-                  type="button"
-                  onClick={() => setShowTimeEstimationModal(true)}
-                  className="text-violet-600 dark:text-violet-400 hover:underline"
-                >
-                  Need help estimating?
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setShowTimePresets(!showTimePresets)}
-                  className="text-violet-600 dark:text-violet-400 hover:underline"
-                >
-                  {showTimePresets ? 'Hide quick presets' : 'Show quick presets'}
-                </button>
-              </div>
-              {showTimePresets && (
-                <div className="mt-1">
-                  <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">Quick presets:</div>
-                  <div className="flex flex-wrap gap-1">
-                    {timePresets.map((preset, index) => (
-                      <button
-                        key={index}
-                        type="button"
-                        onClick={() => setFormData(f => ({
-                          ...f,
-                          estimatedHours: preset.hours,
-                          estimatedMinutes: preset.minutes,
-                        }))}
-                        className="px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-white rounded border transition-colors"
-                      >
-                        {preset.label}
-                      </button>
-                    ))}
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
+                    How long will each work session be?
+                  </label>
+                  <div className="flex gap-2 items-center">
+                    <div className="flex-1">
+                      <input
+                        type="number"
+                        min="0"
+                        max="8"
+                        value={sessionData.sessionHours}
+                        onChange={e => {
+                          const value = e.target.value;
+                          if (value === '' || (/^\d*$/.test(value) && parseInt(value) >= 0 && parseInt(value) <= 8)) {
+                            setSessionData(prev => ({ ...prev, sessionHours: value }));
+                          }
+                        }}
+                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-base focus:ring-2 focus:ring-violet-500 focus:border-transparent bg-white dark:bg-gray-800 dark:text-white"
+                        placeholder="2"
+                      />
+                      <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">Hours</div>
+                    </div>
+                    <div className="text-gray-500 dark:text-gray-400 text-lg font-bold">:</div>
+                    <div className="flex-1">
+                      <input
+                        type="number"
+                        min="0"
+                        max="59"
+                        step="15"
+                        value={sessionData.sessionMinutes}
+                        onChange={e => {
+                          const value = e.target.value;
+                          if (value === '' || /^\d*$/.test(value)) {
+                            const numValue = parseInt(value) || 0;
+                            if (numValue >= 0 && numValue <= 59) {
+                              setSessionData(prev => ({ ...prev, sessionMinutes: value }));
+                            }
+                          }
+                        }}
+                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-base focus:ring-2 focus:ring-violet-500 focus:border-transparent bg-white dark:bg-gray-800 dark:text-white"
+                        placeholder="0"
+                      />
+                      <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">Minutes</div>
+                    </div>
                   </div>
                 </div>
-              )}
-            </div>
+
+                {/* Auto-calculated preview */}
+                {formData.startDate && formData.deadline && (() => {
+                  const calculation = calculateSessionBasedTime();
+                  return (
+                    <div className={`p-3 rounded-lg border ${
+                      calculation.feasible
+                        ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600'
+                        : 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-700'
+                    }`}>
+                      <div className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">Automatic Calculation:</div>
+                      <div className="grid grid-cols-3 gap-3 text-sm">
+                        <div>
+                          <div className="text-gray-500 dark:text-gray-400">Session Duration:</div>
+                          <div className="font-medium text-gray-800 dark:text-white">
+                            {sessionData.sessionHours}h {sessionData.sessionMinutes}m
+                          </div>
+                        </div>
+                        <div>
+                          <div className="text-gray-500 dark:text-gray-400">Planned Sessions:</div>
+                          <div className="font-medium text-gray-800 dark:text-white">
+                            {calculation.sessions} sessions
+                          </div>
+                        </div>
+                        <div>
+                          <div className="text-gray-500 dark:text-gray-400">Total Time:</div>
+                          <div className={`font-medium ${
+                            calculation.feasible
+                              ? 'text-violet-600 dark:text-violet-400'
+                              : 'text-red-600 dark:text-red-400'
+                          }`}>
+                            {calculation.totalTime > 0 ? `${calculation.totalTime.toFixed(1)}h` : 'Set session duration'}
+                          </div>
+                        </div>
+                      </div>
+
+                      {calculation.frequency && (
+                        <div className="mt-2 flex items-center space-x-1">
+                          <span className="text-xs text-gray-500 dark:text-gray-400">Frequency:</span>
+                          <span className="text-xs font-medium text-gray-700 dark:text-gray-300">{calculation.frequency}</span>
+                        </div>
+                      )}
+
+                      {calculation.warning && (
+                        <div className="mt-2 flex items-start space-x-2 text-xs text-red-600 dark:text-red-400">
+                          <svg className="w-4 h-4 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                          </svg>
+                          <span>{calculation.warning}</span>
+                        </div>
+                      )}
+
+                      {calculation.feasible && calculation.totalTime > 0 && (
+                        <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                          The app will automatically schedule {calculation.sessions} sessions based on your availability.
+                        </div>
+                      )}
+                    </div>
+                  );
+                })()}
+
+                {(!formData.startDate || !formData.deadline) && (
+                  <div className="text-sm text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 p-3 rounded-lg flex items-center space-x-2">
+                    <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    <span>Please set both start date and deadline to see the automatic calculation.</span>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
 
           {/* 8. Task Importance */}

--- a/src/components/TaskInputSimplified.tsx
+++ b/src/components/TaskInputSimplified.tsx
@@ -31,6 +31,14 @@ const TaskInputSimplified: React.FC<TaskInputProps> = ({ onAddTask, onCancel, us
     totalTimeNeeded: '',
   });
 
+  // Session-based estimation state
+  const [estimationMode, setEstimationMode] = useState<'total' | 'session'>('total');
+  const [sessionData, setSessionData] = useState({
+    sessionDuration: '2.0',
+    sessionHours: '2',
+    sessionMinutes: '0'
+  });
+
   const [showTimeEstimationModal, setShowTimeEstimationModal] = useState(false);
   const [showHelpModal, setShowHelpModal] = useState(false);
   const [showValidationErrors, setShowValidationErrors] = useState(false);
@@ -61,6 +69,95 @@ const TaskInputSimplified: React.FC<TaskInputProps> = ({ onAddTask, onCancel, us
     }
   }, [formData.deadline]);
 
+  // Calculate session-based total time and metadata (same logic as TaskInput)
+  const calculateSessionBasedTime = () => {
+    if (!formData.startDate || !formData.deadline || estimationMode !== 'session') {
+      return { totalTime: 0, sessions: 0, frequency: '', feasible: true, warning: '' };
+    }
+
+    const startDate = new Date(formData.startDate);
+    const endDate = new Date(formData.deadline);
+    const timeDiff = endDate.getTime() - startDate.getTime();
+    const daysDiff = Math.ceil(timeDiff / (1000 * 3600 * 24));
+
+    if (daysDiff <= 0) {
+      return { totalTime: 0, sessions: 0, frequency: 'Invalid date range', feasible: false, warning: 'Deadline must be after start date' };
+    }
+
+    const sessionDuration = (parseInt(sessionData.sessionHours) || 0) + (parseInt(sessionData.sessionMinutes) || 0) / 60;
+    if (sessionDuration <= 0) {
+      return { totalTime: 0, sessions: 0, frequency: '', feasible: true, warning: '' };
+    }
+
+    // Calculate work days in the range
+    let workDaysInRange = 0;
+    const currentDate = new Date(startDate);
+
+    while (currentDate <= endDate) {
+      const dayOfWeek = currentDate.getDay();
+      if (userSettings.workDays.includes(dayOfWeek)) {
+        workDaysInRange++;
+      }
+      currentDate.setDate(currentDate.getDate() + 1);
+    }
+
+    if (workDaysInRange === 0) {
+      return { totalTime: 0, sessions: 0, frequency: 'No work days', feasible: false, warning: 'No work days in the selected range' };
+    }
+
+    // Calculate optimal session distribution
+    let numberOfSessions;
+    let frequency;
+
+    if (workDaysInRange <= 5) {
+      numberOfSessions = Math.max(1, Math.ceil(workDaysInRange / 2));
+      frequency = 'Every 2-3 days';
+    } else if (workDaysInRange <= 14) {
+      numberOfSessions = Math.max(2, Math.ceil(workDaysInRange * 0.4));
+      frequency = '2-3 times per week';
+    } else {
+      numberOfSessions = Math.max(3, Math.ceil(workDaysInRange * 0.3));
+      frequency = '2-3 times per week';
+    }
+
+    const totalTime = sessionDuration * numberOfSessions;
+
+    // Check feasibility
+    const dailyCapacity = userSettings.dailyAvailableHours;
+    const totalCapacity = workDaysInRange * dailyCapacity;
+    let feasible = true;
+    let warning = '';
+
+    if (sessionDuration > dailyCapacity) {
+      feasible = false;
+      warning = `Session duration (${sessionDuration.toFixed(1)}h) exceeds daily capacity (${dailyCapacity}h)`;
+    } else if (totalTime > totalCapacity * 0.8) {
+      feasible = false;
+      warning = `Total time (${totalTime.toFixed(1)}h) may exceed available capacity`;
+    } else if (numberOfSessions > workDaysInRange) {
+      feasible = false;
+      warning = 'Not enough work days for planned sessions';
+    }
+
+    return { totalTime, sessions: numberOfSessions, frequency, feasible, warning };
+  };
+
+  // Update total time when session data changes
+  useEffect(() => {
+    if (estimationMode === 'session') {
+      const calculation = calculateSessionBasedTime();
+      if (calculation.totalTime > 0) {
+        const hours = Math.floor(calculation.totalTime);
+        const minutes = Math.round((calculation.totalTime - hours) * 60);
+        setFormData(prev => ({
+          ...prev,
+          estimatedHours: hours.toString(),
+          estimatedMinutes: minutes.toString()
+        }));
+      }
+    }
+  }, [sessionData.sessionHours, sessionData.sessionMinutes, formData.startDate, formData.deadline, estimationMode, userSettings.workDays]);
+
   // Reset conflicting options when one-sitting task is toggled
   useEffect(() => {
     if (formData.isOneTimeTask) {
@@ -73,6 +170,15 @@ const TaskInputSimplified: React.FC<TaskInputProps> = ({ onAddTask, onCancel, us
     const h = Math.max(0, parseInt(hours) || 0);
     const m = Math.max(0, Math.min(59, parseInt(minutes) || 0));
     return h + (m / 60);
+  };
+
+  const formatTimeDisplay = (hours: string, minutes: string): string => {
+    const h = parseInt(hours) || 0;
+    const m = parseInt(minutes) || 0;
+    if (h === 0 && m === 0) return '0 minutes';
+    if (h === 0) return `${m} minutes`;
+    if (m === 0) return `${h} hour${h !== 1 ? 's' : ''}`;
+    return `${h} hour${h !== 1 ? 's' : ''} ${m} minutes`;
   };
 
 

--- a/src/components/TaskInputSimplified.tsx
+++ b/src/components/TaskInputSimplified.tsx
@@ -294,15 +294,6 @@ const TaskInputSimplified: React.FC<TaskInputProps> = ({ onAddTask, onCancel, us
                      isStartDateValid &&
                      (!formData.isOneTimeTask || (formData.deadline && !isOneSittingTooLong && !isOneSittingNoTimeSlot));
 
-  const formatTimeDisplay = (hours: string, minutes: string) => {
-    const h = parseInt(hours || '0');
-    const m = parseInt(minutes || '0');
-    if (h === 0 && m === 0) return 'Not set';
-    if (h === 0) return `${m}m`;
-    if (m === 0) return `${h}h`;
-    return `${h}h ${m}m`;
-  };
-
   const getValidationErrors = () => {
     const errors: string[] = [];
     if (!formData.title.trim()) errors.push('Task title is required');


### PR DESCRIPTION
## Purpose

Remove the frequency preference option from session-based planning calculations and default to daily sessions. This simplifies the planning interface by automatically calculating the number of sessions based on available work days between start and deadline dates, eliminating the need for users to manually select frequency preferences.

## Code changes

- **TaskInput.tsx**: Modified `calculateSessionBasedTime()` function to remove frequency preference logic
- **Session calculation**: Now defaults to daily frequency (`const numberOfSessions = workDaysInRange`)
- **UI updates**: Removed frequency selection controls from session-based planning interface
- **Auto-calculation**: Sessions are now automatically determined by counting work days in the date range
- **Display**: Updated session planning preview to show "Daily" as the fixed frequency
- **Service worker**: Updated revision hash for deployment

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/920f388e78f046d0bd10aec57cc875a7/pixel-forge)

👀 [Preview Link](https://920f388e78f046d0bd10aec57cc875a7-pixel-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>920f388e78f046d0bd10aec57cc875a7</projectId>-->
<!--<branchName>pixel-forge</branchName>-->